### PR TITLE
Update 1_features.py

### DIFF
--- a/bregman/examples/1_features.py
+++ b/bregman/examples/1_features.py
@@ -69,7 +69,7 @@ def ex_1c(x):
     Window parameters set for trade-off between narrow and wide band analysis
     (harmonics + formants)
     """
-    F = LinearFrequencySpectrum(x, nfft=1024, wfft=512, nhop=512)
+    F = LinearFrequencySpectrum(x, nfft=1024, wfft=512, nhop=510)
     F.feature_plot(dbscale=True, normalize=True)
     title('Medium-band magnitude short-time Fourier transform (STFT)')
 


### PR DESCRIPTION
For some reason, the nhop value of 512 (while nfft = 1024 & wfft = 512) generates the following error.
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-3-c38417c53a5d> in <module>()
    158     F1a = ex_1a(audio_file)
    159     F1b = ex_1b(audio_file)
--> 160     F1c = ex_1c(audio_file)
    161     F2a = ex_2a(audio_file)
    162     F3a = ex_3a(audio_file)

<ipython-input-3-c38417c53a5d> in ex_1c(x)
     70 (harmonics + formants)
     71 """
---> 72     F = LinearFrequencySpectrum(x, nfft=1024, wfft=512, nhop=512)
     73     F.feature_plot(dbscale=True, normalize=True)
     74     title('Medium-band magnitude short-time Fourier transform (STFT)')

/usr/local/lib/python2.7/dist-packages/bregman/features.pyc in __init__(self, arg, **feature_params)
    111     def __init__(self, arg=None, **feature_params):
    112         feature_params['feature']='stft'
--> 113         Features.__init__(self, arg, feature_params)
    114 
    115 class LogFrequencySpectrum(Features):

/usr/local/lib/python2.7/dist-packages/bregman/features_base.pyc in __init__(self, arg, feature_params)
     68             if arg:
     69                 self.load_audio(arg) # open file as MONO signal
---> 70                 self.extract()
     71 
     72     def _initialize(self, feature_params):

/usr/local/lib/python2.7/dist-packages/bregman/features_base.pyc in extract(self, feature_params)
    211         """
    212         f = self._check_feature_params(feature_params)['feature']
--> 213         self.extract_funs.get(f, self._extract_error)()
    214         if self.onsets: self._extract_onsets()
    215 

/usr/local/lib/python2.7/dist-packages/bregman/features_base.pyc in _stft(self)
    413             self._shift_insert(x, nex, self.nhop)
    414             if self.nhop >= self.wfft - k*self.nhop : # align buffer on start of audio
--> 415                 self.STFT[:,k-buf_frames]=P.rfft(x, self.nfft).T # win*x
    416             else:
    417                 buf_frames+=1

IndexError: index 535 is out of bounds for axis 1 with size 535

Lowering the value of nhop seems to circumvent the error. Your choice whether to find the bug now or just lower nhop.